### PR TITLE
Identify system using uname -a instead of /etc/issue

### DIFF
--- a/bootstrap-debian-dev.sh
+++ b/bootstrap-debian-dev.sh
@@ -13,7 +13,6 @@ MIRROR="debian.mirrors.opennms.org"
 ANSWER="No"
 
 REQUIRED_SYSTEMS="Ubuntu|Debian"
-RELEASE_FILE="/etc/issue"
 
 # Error codes
 E_ILLEGAL_ARGS=126
@@ -68,7 +67,7 @@ showDisclaimer() {
 }
 
 # Test if system is supported
-cat ${RELEASE_FILE} | grep -E ${REQUIRED_SYSTEMS}  1>/dev/null 2>>${ERROR_LOG}
+uname -a | grep -E ${REQUIRED_SYSTEMS}  1>/dev/null 2>>${ERROR_LOG}
 if [ ! ${?} -eq 0 ]; then
   echo ""
   echo "This is system is not a supported Ubuntu or Debian system."

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -13,7 +13,6 @@ MIRROR="debian.opennms.org"
 ANSWER="No"
 
 REQUIRED_SYSTEMS="Ubuntu|Debian"
-RELEASE_FILE="/etc/issue"
 
 # Error codes
 E_ILLEGAL_ARGS=126
@@ -79,7 +78,7 @@ showDisclaimer() {
 }
 
 # Test if system is supported
-grep -E "${REQUIRED_SYSTEMS}" "${RELEASE_FILE}" 1>/dev/null 2>>${ERROR_LOG}
+uname -a | grep -E "${REQUIRED_SYSTEMS}"  1>/dev/null 2>>"${ERROR_LOG}"
 if [ ! "${?}" -eq 0 ]; then
   echo ""
   echo "This is system is not a supported Ubuntu or Debian system."
@@ -285,4 +284,3 @@ echo "Select in the main navigation \"Admin\" and go to \"Change Password\""
 echo ""
 echo "Thank you computing with us."
 echo ""
-


### PR DESCRIPTION
Changed the way to identify the supported system using `uname -a` instead of relying on the content of `/etc/issue` which can be changed by a user.

Resolves #8 