### PR TITLE
Issue/11: Drop support for legacy sysvinit service startup

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -256,7 +256,10 @@ initializeOnmsDb() {
 restartOnms() {
   printf 'START_TIMEOUT=0' > "${OPENNMS_HOME}/etc/opennms.conf"
   echo -n "Starting OpenNMS                      ... "
-  service opennms restart 1>/dev/null 2>>${ERROR_LOG}
+  systemctl start opennms 1>/dev/null 2>>${ERROR_LOG}
+  checkError ${?}
+  echo -n "OpenNMS systemd enable                ... "
+  systemctl enable opennms 1>/dev/null 2>>${ERROR_LOG}
   checkError ${?}
 }
 

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -250,6 +250,7 @@ initializeOnmsDb() {
 }
 
 restartOnms() {
+  printf 'START_TIMEOUT=0' > "${OPENNMS_HOME}/etc/opennms.conf"
   echo -n "Starting OpenNMS                      ... "
   systemctl start opennms 1>/dev/null 2>>${ERROR_LOG}
   checkError ${?}


### PR DESCRIPTION
Replace `service` with native `systemctl` command and drop support for older distributions without Systemd. Additional remove blocking on wait to start OpenNMS services with setting the `START_TIMEOUT=0` by creating an `opennms.conf`.