### PR TITLE
fix Ubuntu detection on 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bootstrap.log

--- a/bootstrap-debian-dev.sh
+++ b/bootstrap-debian-dev.sh
@@ -34,8 +34,12 @@ usage() {
 
 checkRequirements() {
   # Test if system is supported
-  uname -a | grep -E "${REQUIRED_SYSTEMS}"  1>/dev/null 2>>"${ERROR_LOG}"
-  if [ ! "${?}" -eq 0 ]; then
+  DISTRO_CHECK="$(command -v lsb_release)"
+  if [ -z "$DISTRO_CHECK" ]; then
+    DISTRO_CHECK="$(command -v uname)"
+  fi
+  "$DISTRO_CHECK" -a | grep -E "${REQUIRED_SYSTEMS}"  1>/dev/null 2>>"${ERROR_LOG}"
+  if [ ! "${?}" -eq 0 ] && [ ! -e /etc/debian_version ]; then
     echo ""
     echo "This is system is not a supported Ubuntu or Debian system."
     echo ""

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -34,8 +34,12 @@ usage() {
 
 checkRequirements() {
   # Test if system is supported
-  uname -a | grep -E "${REQUIRED_SYSTEMS}"  1>/dev/null 2>>"${ERROR_LOG}"
-  if [ ! "${?}" -eq 0 ]; then
+  DISTRO_CHECK="$(command -v lsb_release)"
+  if [ -z "$DISTRO_CHECK" ]; then
+    DISTRO_CHECK="$(command -v uname)"
+  fi
+  "$DISTRO_CHECK" -a | grep -E "${REQUIRED_SYSTEMS}"  1>/dev/null 2>>"${ERROR_LOG}"
+  if [ ! "${?}" -eq 0 ] && [ ! -e /etc/debian_version ]; then
     echo ""
     echo "This is system is not a supported Ubuntu or Debian system."
     echo ""


### PR DESCRIPTION
This PR makes the installer script(s) prefer `lsb_release` over `uname` in cases where it exists.  This fixes distro detection on Ubuntu 18, which does not contain the string "Ubuntu" in its `uname -a` output.