### PR TITLE
fix: issue #35 variable {DB_NAME} not referenced correctly

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -171,7 +171,7 @@ queryDbCredentials() {
   echo ""
   echo "Create OpenNMS Horizon database with user credentials"
   echo ""
-  read -r -p    "Database name for OpenNMS Horizon (default: opennms): " DB_NAME
+  read -r -p    "Database name for OpenNMS Horizon (default: opennms): " ${DB_NAME}
   read -r -p    "User for the database: " DB_USER
   while true; do
     read -r -s -p "New password: " DB_PASS


### PR DESCRIPTION
Fix default values when installing on Debian. We need to verify if we use the wrong default value references in other places as well, and also need to verify if we have the same problem in the yum install script.

Kudos to @md1986 for reporting the bug and looking into fixing it.

Resolve: #35 