### PR TITLE
fix: Allow users the installation using default values for the database

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -163,8 +163,12 @@ queryDbCredentials() {
     echo ""
     read -r -s -p "Confirm postgres password: " POSTGRES_PASS_CONFIRM
     echo ""
-    [ "${POSTGRES_PASS}" = "${POSTGRES_PASS_CONFIRM}" ] && break
-    echo "Password confirmation didn't match, please try again."
+    if [ ! -z "${POSTGRES_PASS}" ]; then
+      [ "${POSTGRES_PASS}" = "${POSTGRES_PASS_CONFIRM}" ] && break
+      echo "Password confirmation didn't match, please try again."
+    else
+      echo "Password for the PostgreSQL user can't be empty. Please set a password."
+    fi
     echo ""
   done
   echo ""
@@ -172,14 +176,20 @@ queryDbCredentials() {
   echo "Create OpenNMS Horizon database with user credentials"
   echo ""
   read -r -p    "Database name for OpenNMS Horizon (default: opennms): " DB_NAME
-  read -r -p    "User for the database: " DB_USER
+  DB_NAME="${DB_NAME:-opennms}"
+  read -r -p    "User for the database (default: opennms): " DB_USER
+  DB_USER="${DB_USER:-opennms}"
   while true; do
     read -r -s -p "New password: " DB_PASS
     echo ""
     read -r -s -p "Confirm password: " DB_PASS_CONFIRM
     echo ""
-    [ "${DB_PASS}" = "${DB_PASS_CONFIRM}" ] && break
-    echo "Password confirmation didn't match, please try again."
+    if [ ! -z "${DB_PASS}" ]; then
+      [ "${DB_PASS}" = "${DB_PASS_CONFIRM}" ] && break
+      echo "Password confirmation didn't match, please try again."
+    else
+      echo "Password for the OpenNMS database user can't be empty. Please set a password."
+    fi
     echo ""
   done
   echo ""

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -154,8 +154,12 @@ queryDbCredentials() {
     echo ""
     read -r -s -p "Confirm postgres password: " POSTGRES_PASS_CONFIRM
     echo ""
-    [ "${POSTGRES_PASS}" = "${POSTGRES_PASS_CONFIRM}" ] && break
-    echo "Password confirmation didn't match, please try again."
+    if [ ! -z "${POSTGRES_PASS}" ]; then
+      [ "${POSTGRES_PASS}" = "${POSTGRES_PASS_CONFIRM}" ] && break
+      echo "Password confirmation didn't match, please try again."
+    else
+      echo "Password for the PostgreSQL user can't be empty. Please set a password."
+    fi
     echo ""
   done
   echo ""
@@ -163,14 +167,20 @@ queryDbCredentials() {
   echo "Create OpenNMS Horizon database with user credentials"
   echo ""
   read -r -p    "Database name for OpenNMS Horizon (default: opennms): " DB_NAME
-  read -r -p    "User for the database: " DB_USER
+  DB_NAME="${DB_NAME:-opennms}"
+  read -r -p    "User for the database (default: opennms): " DB_USER
+  DB_USER="${DB_USER:-opennms}"
   while true; do
     read -r -s -p "New password: " DB_PASS
     echo ""
     read -r -s -p "Confirm password: " DB_PASS_CONFIRM
     echo ""
-    [ "${DB_PASS}" = "${DB_PASS_CONFIRM}" ] && break
-    echo "Password confirmation didn't match, please try again."
+    if [ ! -z "${DB_PASS}" ]; then
+      [ "${DB_PASS}" = "${DB_PASS_CONFIRM}" ] && break
+      echo "Password confirmation didn't match, please try again."
+    else
+      echo "Password for the OpenNMS database user can't be empty. Please set a password."
+    fi
     echo ""
   done
   echo ""


### PR DESCRIPTION
Set a fall back for the OpenNMS database user name to opennms. Also added a sanitycheck for the password input preventing empty passwords, which are not allowed.

Kudos to @md1986 for reporting the bug and looking into fixing it.

Resolve: #35