### PR TITLE
fix: Enforce UTF8 when database is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The script is tested with:
 
 * Ubuntu 22.04.2 (Jammy) x86_64
 * Debian 12 (Bookworm) x86_64
-* Rocky Linux 9.2 (Blue Onyx) x86_64
+* Rocky Linux 9.3 (Blue Onyx) x86_64
 * AlmaLinux 8.8 (Sapphire Caracal) x86_64
 * AlmaLinux 9.3 (Shamrock Pampas Cat) x86_64
 

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -207,7 +207,7 @@ setDbCredentials() {
     sudo -i -u postgres psql -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASS}';"
     sudo -i -u postgres psql -c "CREATE USER ${DB_USER} WITH PASSWORD '${DB_PASS}';"
     sudo -i -u postgres psql -c "GRANT CREATE ON SCHEMA public TO PUBLIC;"
-    sudo -i -u postgres psql -c "CREATE DATABASE ${DB_NAME} WITH OWNER ${DB_USER};"
+    sudo -i -u postgres psql -c "CREATE DATABASE ${DB_NAME} WITH OWNER ${DB_USER} ENCODING UTF8 TEMPLATE template0;"
   } 1>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -198,7 +198,7 @@ setDbCredentials() {
     sudo -i -u postgres psql -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASS}';"
     sudo -i -u postgres psql -c "CREATE USER ${DB_USER} WITH PASSWORD '${DB_PASS}';"
     sudo -i -u postgres psql -c "GRANT CREATE ON SCHEMA public TO PUBLIC;"
-    sudo -i -u postgres psql -c "CREATE DATABASE ${DB_NAME} WITH OWNER ${DB_USER};"
+    sudo -i -u postgres psql -c "CREATE DATABASE ${DB_NAME} WITH OWNER ${DB_USER} ENCODING UTF8 TEMPLATE template0;"
   } 1>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }


### PR DESCRIPTION
The database is created with UTF8 independently from the systems locale setting from template0

Resolve: #38