### PR TITLE
feat(installer): upgrade to Temurin JDK 21 across all distributions

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 #
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # Script to bootstrap a basic OpenNMS setup
 
 set -eEuo pipefail

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -21,7 +21,7 @@ GREEN="\e[32m"
 ENDCOLOR="\e[0m"
 
 REQUIRED_SYSTEMS="Ubuntu|Debian"
-REQUIRED_JDK="temurin-21-jdk"
+REQUIRED_JDK="21"
 PSQL_MAX_VERSION=15
 IP_ADDRESS=$(hostname -I | awk '{print $1}') # export the address so it can also be used in the timeout command
 
@@ -55,12 +55,7 @@ checkRequirements() {
   fi
 
   # Test if system is supported
-  DISTRO_CHECK="$(command -v lsb_release 2>>"${ERROR_LOG}")"
-  if [[ -z "${DISTRO_CHECK}" ]]; then
-    DISTRO_CHECK="$(command -v uname)"
-  fi
-
-  if ! "${DISTRO_CHECK}" -a | grep -E "${REQUIRED_SYSTEMS}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}" && [[ ! -e /etc/debian_version ]]; then
+  if ! lsb_release -a | grep -E "${REQUIRED_SYSTEMS}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}" && [[ ! -e /etc/debian_version ]]; then
     echo ""
     echo "This is system is not a supported Ubuntu or Debian system."
     echo ""
@@ -92,7 +87,7 @@ showDisclaimer() {
   echo "components:"
   echo ""
   echo " - Installing installer dependencies curl, gnupg2, apt-transport-https"
-  echo " - Eclipse Adoptium Temurin JDK 21"
+  echo " - Eclipse Adoptium Temurin JDK ${REQUIRED_JDK}"
   echo " - PostgreSQL Server"
   echo " - Initializing database access with credentials"
   echo " - OpenNMS Repositories"
@@ -239,24 +234,36 @@ EOF
 }
 
 ####
-# Install Eclipse Adoptium Temurin JDK 21
+# Install Eclipse Adoptium Temurin JDK
 installJdk() {
-  echo -n "📦 Add Adoptium repository key          ... "
+  if dpkg -s "temurin-${REQUIRED_JDK}-jdk" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"; then
+    echo "📦 Install Temurin Java Development Kit  ... [ SKIP ] Already installed"
+    return
+  fi
+  DEB_CODENAME="$(lsb_release -cs)"
+  echo -n "📦 Check Adoptium supports your system   ... "
+  if ! curl -1sLf -o /dev/null "https://packages.adoptium.net/artifactory/deb/dists/${DEB_CODENAME}/Release" 2>>"${ERROR_LOG}"; then
+    echo -e "[ ${RED}FAILED${ENDCOLOR} ]"
+    echo ""
+    echo "The Adoptium apt repository does not publish packages for '${DEB_CODENAME}'."
+    echo "See https://packages.adoptium.net/artifactory/deb/dists/ for supported"
+    echo "releases, or install a Temurin ${REQUIRED_JDK} JDK manually and re-run this script."
+    echo ""
+    exit "${E_UNSUPPORTED}"
+  fi
+  echo -e "[ ${GREEN}OK${ENDCOLOR} ]"
+  echo -n "📦 Add Adoptium repository key           ... "
   curl -1sLf "https://packages.adoptium.net/artifactory/api/gpg/key/public" | gpg --dearmor | sudo tee "/usr/share/keyrings/adoptium.gpg" 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  echo -n "📦 Add Adoptium repository              ... "
-  echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list 1>/dev/null 2>>"${ERROR_LOG}"
+  echo -n "📦 Add Adoptium repository               ... "
+  echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb ${DEB_CODENAME} main" | sudo tee /etc/apt/sources.list.d/adoptium.list 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  echo -n "📦 Update APT cache                      ... "
+  echo -n "📦 Update apt cache                      ... "
   sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "📦 Install Temurin Java Development Kit  ... "
-  if ! apt list --installed 2>>"${ERROR_LOG}" | grep "${REQUIRED_JDK}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"; then
-    sudo apt-get install -y --no-install-recommends "${REQUIRED_JDK}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-    checkError "${?}"
-  else
-    echo "[ SKIP ] Already installed"
-  fi
+  sudo apt-get install -y --no-install-recommends "temurin-${REQUIRED_JDK}-jdk" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
 }
 
 ####

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -21,7 +21,7 @@ GREEN="\e[32m"
 ENDCOLOR="\e[0m"
 
 REQUIRED_SYSTEMS="Ubuntu|Debian"
-REQUIRED_JDK="openjdk-17-jdk"
+REQUIRED_JDK="temurin-21-jdk"
 PSQL_MAX_VERSION=15
 IP_ADDRESS=$(hostname -I | awk '{print $1}') # export the address so it can also be used in the timeout command
 
@@ -55,7 +55,7 @@ checkRequirements() {
   fi
 
   # Test if system is supported
-  DISTRO_CHECK="$(command -v lsb_release 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}")"
+  DISTRO_CHECK="$(command -v lsb_release 2>>"${ERROR_LOG}")"
   if [[ -z "${DISTRO_CHECK}" ]]; then
     DISTRO_CHECK="$(command -v uname)"
   fi
@@ -92,7 +92,7 @@ showDisclaimer() {
   echo "components:"
   echo ""
   echo " - Installing installer dependencies curl, gnupg2, apt-transport-https"
-  echo " - OpenJDK Development Kit"
+  echo " - Eclipse Adoptium Temurin JDK 21"
   echo " - PostgreSQL Server"
   echo " - Initializing database access with credentials"
   echo " - OpenNMS Repositories"
@@ -239,12 +239,20 @@ EOF
 }
 
 ####
-# Install OpenJDK Development kit
+# Install Eclipse Adoptium Temurin JDK 21
 installJdk() {
-  # Test if a OpenJDK 17 Development Kit is installed
-  echo -n "📦 Install OpenJDK Development Kit       ... "
+  echo -n "📦 Add Adoptium repository key          ... "
+  curl -1sLf "https://packages.adoptium.net/artifactory/api/gpg/key/public" | gpg --dearmor | sudo tee "/usr/share/keyrings/adoptium.gpg" 1>/dev/null 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Add Adoptium repository              ... "
+  echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list 1>/dev/null 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Update APT cache                      ... "
+  sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Install Temurin Java Development Kit  ... "
   if ! apt list --installed 2>>"${ERROR_LOG}" | grep "${REQUIRED_JDK}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"; then
-    sudo apt-get install -y --no-install-recommends ${REQUIRED_JDK} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+    sudo apt-get install -y --no-install-recommends "${REQUIRED_JDK}" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
     checkError "${?}"
   else
     echo "[ SKIP ] Already installed"

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -21,7 +21,7 @@ YELLOW="\e[33m"
 ENDCOLOR="\e[0m"
 SUPPORTED_DISTROS="RHEL 9/10, CentOS 9/10, Rocky 9/10, Alma 9/10"
 REQUIRED_SYSTEMS="^(Red Hat Enterprise Linux|Rocky Linux|CentOS Stream|AlmaLinux) release 9([.][0-9]+)?|10([.][0-9]+)? \(.+\)$"
-REQUIRED_JDK="17"
+REQUIRED_JDK="21"
 RELEASE_FILE="/etc/redhat-release"
 OS_MAJOR_VERSION=$(grep -oE '[0-9]+' /etc/redhat-release | head -1)
 PSQL_MAX_VERSION=15
@@ -82,7 +82,7 @@ showDisclaimer() {
   echo "components:"
   echo ""
   echo " - Installing curl"
-  echo " - OpenJDK Development Kit"
+  echo " - Eclipse Adoptium Temurin JDK 21"
   echo " - PostgreSQL Server"
   echo " - Initializing database access with credentials"
   echo " - OpenNMS Repositories"
@@ -225,7 +225,7 @@ EOF
 }
 
 ####
-# Install OpenJDK Development kit
+# Install Eclipse Adoptium Temurin JDK 21
 installJdk() {
   echo "📦 Adding Adoptium Repo                  ... "
   cat <<EOF | sudo tee /etc/yum.repos.d/adoptium.repo > /dev/null
@@ -245,7 +245,7 @@ EOF
 # Install the PostgreSQL database
 installPostgres() {
   echo "📦 Add PostgreSQL repository             ... "
-  sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_MAJOR_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+  sudo dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_MAJOR_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
   checkError "${?}"
   echo -n "📦 Install PostgreSQL ${PSQL_MAX_VERSION} database        ... "
   sudo dnf install -y postgresql${PSQL_MAX_VERSION}-server 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 #
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # Script to bootstrap a basic OpenNMS setup
 
 set -eEuo pipefail

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -82,7 +82,7 @@ showDisclaimer() {
   echo "components:"
   echo ""
   echo " - Installing curl"
-  echo " - Eclipse Adoptium Temurin JDK 21"
+  echo " - Eclipse Adoptium Temurin JDK ${REQUIRED_JDK}"
   echo " - PostgreSQL Server"
   echo " - Initializing database access with credentials"
   echo " - OpenNMS Repositories"
@@ -225,13 +225,15 @@ EOF
 }
 
 ####
-# Install Eclipse Adoptium Temurin JDK 21
+# Install Eclipse Adoptium Temurin JDK
 installJdk() {
   echo "📦 Adding Adoptium Repo                  ... "
+  # Use the OS major version: Adoptium only publishes per-major repos, and
+  # $releasever expands to e.g. 9.6 on RHEL EUS/RHUI systems, which 404s.
   cat <<EOF | sudo tee /etc/yum.repos.d/adoptium.repo > /dev/null
 [Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/centos/\$releasever/\$basearch
+baseurl=https://packages.adoptium.net/artifactory/rpm/centos/${OS_MAJOR_VERSION}/\$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public


### PR DESCRIPTION
### Summary

Upgrades bootstrap-debian.sh and bootstrap-yum.sh to install Eclipse Adoptium Temurin JDK 21 (temurin-21-jdk) across all supported Linux distributions. This standardizes the JDK runtime environment required for OpenNMS Horizon 36.0.3.

### Changes Included

- Added Adoptium GPG keyring (/usr/share/keyrings/adoptium.gpg) and APT repository setup in bootstrap-debian.sh
- Updated JDK package requirement to temurin-21-jdk in bootstrap-debian.sh
- Updated REQUIRED_JDK variable to 21 in bootstrap-yum.sh to install temurin-21-jdk
- Verified script formatting and syntax using ShellCheck

Closes #58