### PR TITLE
fix(debian): avoid duplicate OpenJDK install next to Temurin

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -298,7 +298,10 @@ installOnmsRepo() {
 # Install the OpenNMS application from Debian repository
 installOnmsApp() {
   echo -n "📦 Install OpenNMS Horizon packages      ... "
-  sudo apt-get install -y -qq rrdtool jrrd2 jicmp jicmp6 opennms opennms-webapp-hawtio 2>>"${ERROR_LOG}"
+  # --no-install-recommends: opennms recommends openjdk-21, which apt would
+  # install next to the Temurin JDK because temurin-21-jdk does not provide
+  # any name in the recommends list, see issue #48.
+  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms opennms-webapp-hawtio 2>>"${ERROR_LOG}"
   sudo -u opennms "${OPENNMS_HOME}"/bin/runjava -s 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }


### PR DESCRIPTION
Closes #48.

`opennms` 36.x declares `Recommends: jdk-21 | openjdk-21-jdk-headless | openjdk-21-jdk | adoptopenjdk-21-* | java21-jdk`, while `temurin-21-jdk` provides `java21-sdk` but none of those names (verified against the live Adoptium and OpenNMS package indexes). apt therefore treats the recommends group as unsatisfied and installs `openjdk-21-jdk-headless` alongside the Temurin JDK the bootstrap already installed, which is what the reporter saw during their upgrade.

This installs the OpenNMS packages with `--no-install-recommends`. The dropped recommends are `haveged` (not needed with in-kernel entropy on modern kernels), `opennms-source` and optional perl helper tools on `opennms-common`; all hard dependencies (`opennms-server`, `opennms-db`, `opennms-webapp-jetty`, PostgreSQL alternatives, etc.) still install. `iplike` is not pulled via recommends in 36.x, so nothing load-bearing is lost.

Two caveats worth recording:

- A later manual `apt upgrade` to a new OpenNMS major will still pull the recommended OpenJDK, because apt's default recommends handling applies outside this script. The complete fix is upstream: the `opennms` debian packaging should add `temurin-21-jdk` (or the virtual `java21-sdk`, which all Temurin packages provide) to its recommends alternatives.
- The other half of #48 (upgrades blocked by held packages) is intentional: `disableRepo()` holds the OpenNMS packages on purpose to prevent unintended major upgrades; `apt-mark unhold` is the documented escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)