### PR TITLE
ci: add integration test matrix workflow across 8 Linux target releases

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,49 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  integration-test:
+    name: "${{ matrix.distro }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: "Debian 13 (Trixie)"
+            image: "debian:trixie"
+            script: "bootstrap-debian.sh"
+          - distro: "Ubuntu 24.04 LTS"
+            image: "ubuntu:24.04"
+            script: "bootstrap-debian.sh"
+          - distro: "CentOS Stream 9"
+            image: "quay.io/centos/centos:stream9"
+            script: "bootstrap-yum.sh"
+          - distro: "CentOS Stream 10"
+            image: "quay.io/centos/centos:stream10"
+            script: "bootstrap-yum.sh"
+          - distro: "AlmaLinux 9"
+            image: "almalinux:9"
+            script: "bootstrap-yum.sh"
+          - distro: "AlmaLinux 10"
+            image: "almalinux:10"
+            script: "bootstrap-yum.sh"
+          - distro: "Rocky Linux 9"
+            image: "rockylinux/rockylinux:9"
+            script: "bootstrap-yum.sh"
+          - distro: "Rocky Linux 10"
+            image: "rockylinux/rockylinux:10"
+            script: "bootstrap-yum.sh"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Run integration test
+        run: make integration-test IMAGE="${{ matrix.image }}" SCRIPT="${{ matrix.script }}"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
             script: "bootstrap-yum.sh"
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
 
       - name: Run integration test
         run: make integration-test IMAGE="${{ matrix.image }}" SCRIPT="${{ matrix.script }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 .idea/
 bootstrap.log
 
+# AI tools
+_bmad-output/
+_bmad/
+openspec/
+.claude/
+.agent/
+.agents/
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+IMAGE ?= debian:trixie
+SCRIPT ?= bootstrap-debian.sh
+
+.PHONY: integration-test
+integration-test:
+	tests/integration-test.sh "$(IMAGE)" "$(SCRIPT)"

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -13,10 +13,13 @@ trap 's=${?}; echo >&2 "${0}: Error on line "${LINENO}": ${BASH_COMMAND}"; exit 
 export DEBIAN_FRONTEND=noninteractive
 ERROR_LOG="bootstrap.log"
 POSTGRES_USER="postgres"
-POSTGRES_PASS=""
-DB_NAME="opennms"
-DB_USER="opennms"
-DB_PASS="opennms"
+POSTGRES_PASS="${POSTGRES_PASS:-}"
+DB_NAME="${DB_NAME:-opennms}"
+DB_USER="${DB_USER:-opennms}"
+DB_PASS="${DB_PASS:-opennms}"
+# Set ONMS_UNATTENDED=yes to skip the confirmation and credential prompts,
+# e.g. for CI. Requires POSTGRES_PASS to be set in the environment.
+UNATTENDED="${ONMS_UNATTENDED:-no}"
 OPENNMS_HOME="/opt/opennms"
 ANSWER="No"
 RED="\e[31m"
@@ -108,6 +111,15 @@ showDisclaimer() {
   echo ""
   echo " - https://github.com/opennms-forge/opennms-install/issues -"
   echo ""
+
+  if [[ "${UNATTENDED}" == "yes" ]]; then
+    echo "🤖 Unattended mode, skipping confirmation"
+    echo ""
+    echo "🚀 Starting setup procedure"
+    echo ""
+    return
+  fi
+
   read -r -p "If you want to proceed, type YES: " ANSWER
 
   # Set bash to case insensitive
@@ -174,6 +186,14 @@ prepare() {
 # Helper to request Postgres credentials to initialize the
 # OpenNMS database.
 queryDbCredentials() {
+  if [[ "${UNATTENDED}" == "yes" ]]; then
+    if [[ -z "${POSTGRES_PASS}" ]]; then
+      echo "Unattended mode requires the POSTGRES_PASS environment variable to be set."
+      exit "${E_ILLEGAL_ARGS}"
+    fi
+    return
+  fi
+
   echo "👩‍💻 Enter credentials for the database and connection"
   echo "   Set a Postgres root password"
   while true; do
@@ -284,14 +304,25 @@ installPostgres() {
   echo -n "📦 Install PostgreSQL database           ... "
   sudo apt-get install -y postgresql-${PSQL_MAX_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
+  # The postinst normally starts the cluster; make sure it runs on systems
+  # where deferred service starts are policy (e.g. containers).
+  echo -n "🚀 Start PostgreSQL database             ... "
+  sudo systemctl start postgresql 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
 }
 
 ####
 # Install OpenNMS Debian repository for specific release
 installOnmsRepo() {
-  echo "📦 Install Horizon Repository            ... "
-  curl -1sLf 'https://packages.opennms.com/public/stable/setup.deb.sh' | sudo -E bash
-  curl -1sLf 'https://packages.opennms.com/public/common/setup.deb.sh' | sudo -E bash
+  echo -n "📦 Add OpenNMS repository key            ... "
+  curl -1sLf "https://debian.opennms.org/OPENNMS-GPG-KEY" | gpg --dearmor | sudo tee "/usr/share/keyrings/opennms.gpg" 1>/dev/null 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Add OpenNMS repository                ... "
+  echo "deb [signed-by=/usr/share/keyrings/opennms.gpg] https://debian.opennms.org stable main" | sudo tee /etc/apt/sources.list.d/opennms.list 1>/dev/null 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Update apt cache                      ... "
+  sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
 }
 
 ####
@@ -312,8 +343,10 @@ installOnmsApp() {
 setCredentials() {
   echo ""
   echo -n "👩‍🔧 Create secure vault for Postgres      ... "
-  sudo -u opennms ${OPENNMS_HOME}/bin/scvcli set postgres "${DB_USER}" "${DB_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
-  sudo -u opennms ${OPENNMS_HOME}/bin/scvcli set postgres-admin "${POSTGRES_USER}" "${POSTGRES_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
+  # Run scvcli with bash: the script uses the bashism $(<java.conf) but has
+  # a /bin/sh shebang, which breaks on Debian where /bin/sh is dash.
+  sudo -u opennms bash "${OPENNMS_HOME}/bin/scvcli" set postgres "${DB_USER}" "${DB_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
+  sudo -u opennms bash "${OPENNMS_HOME}/bin/scvcli" set postgres-admin "${POSTGRES_USER}" "${POSTGRES_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "🔧 Generate OpenNMS database config      ... "
   if [[ -f "${OPENNMS_HOME}"/etc/opennms-datasources.xml ]]; then
@@ -418,7 +451,7 @@ waitForStart() {
 }
 
 # Execute setup procedure
-clear
+clear 2>/dev/null || true # No TTY in unattended runs
 checkRequirements
 showDisclaimer
 prepare

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -12,10 +12,13 @@ trap 's=${?}; echo >&2 "${0}: Error on line "${LINENO}": ${BASH_COMMAND}"; exit 
 # Default build identifier set to stable
 ERROR_LOG="bootstrap.log"
 POSTGRES_USER="postgres"
-POSTGRES_PASS=""
-DB_NAME="opennms"
-DB_USER="opennms"
-DB_PASS="opennms"
+POSTGRES_PASS="${POSTGRES_PASS:-}"
+DB_NAME="${DB_NAME:-opennms}"
+DB_USER="${DB_USER:-opennms}"
+DB_PASS="${DB_PASS:-opennms}"
+# Set ONMS_UNATTENDED=yes to skip the confirmation and credential prompts,
+# e.g. for CI. Requires POSTGRES_PASS to be set in the environment.
+UNATTENDED="${ONMS_UNATTENDED:-no}"
 OPENNMS_HOME="/opt/opennms"
 ANSWER="No"
 RED="\e[31m"
@@ -103,6 +106,15 @@ showDisclaimer() {
   echo ""
   echo " - https://github.com/opennms-forge/opennms-install/issues -"
   echo ""
+
+  if [[ "${UNATTENDED}" == "yes" ]]; then
+    echo "🤖 Unattended mode, skipping confirmation"
+    echo ""
+    echo "🚀 Starting setup procedure"
+    echo ""
+    return
+  fi
+
   read -r -p "If you want to proceed, type YES: " ANSWER
 
   # Set bash to case insensitive
@@ -157,8 +169,9 @@ prepare() {
   checkError "${?}"
 
   # Ensure curl and gnupg2 is available
+  # --allowerasing: EL ships curl-minimal which conflicts with curl
   echo -n "📦 Install curl                          ... "
-  sudo dnf -y install curl 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo dnf -y install --allowerasing curl 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }
 
@@ -166,6 +179,14 @@ prepare() {
 # Helper to request Postgres credentials to initialize the
 # OpenNMS database.
 queryDbCredentials() {
+  if [[ "${UNATTENDED}" == "yes" ]]; then
+    if [[ -z "${POSTGRES_PASS}" ]]; then
+      echo "Unattended mode requires the POSTGRES_PASS environment variable to be set."
+      exit "${E_ILLEGAL_ARGS}"
+    fi
+    return
+  fi
+
   echo "👩‍💻 Enter credentials for the database and connection"
   echo "   Set a Postgres root password"
   while true; do
@@ -250,7 +271,7 @@ EOF
 # Install the PostgreSQL database
 installPostgres() {
   echo "📦 Add PostgreSQL repository             ... "
-  sudo dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_MAJOR_VERSION}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+  sudo dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_MAJOR_VERSION}-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm"
   checkError "${?}"
   echo -n "📦 Install PostgreSQL ${PSQL_MAX_VERSION} database        ... "
   sudo dnf install -y postgresql${PSQL_MAX_VERSION}-server 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
@@ -260,9 +281,12 @@ installPostgres() {
 ####
 # Install OpenNMS rpm repository for specific release
 installOnmsRepo() {
-  echo "📦 Install OpenNMS Repository            ... "
-  sudo dnf -y install https://yum.opennms.org/repofiles/opennms-repo-stable-rhel9.noarch.rpm
-  sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/opennms-repo-stable-rhel9.repo
+  echo -n "📦 Install OpenNMS repository            ... "
+  sudo dnf -y install "https://yum.opennms.org/repofiles/opennms-repo-stable-rhel${OS_MAJOR_VERSION}.noarch.rpm" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
+  echo -n "📦 Disable GPG check on repository       ... "
+  sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/opennms-repo-stable-*.repo 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  checkError "${?}"
 }
 
 ####
@@ -412,7 +436,7 @@ waitForStart() {
 }
 
 # Execute setup procedure
-clear
+clear 2>/dev/null || true # No TTY in unattended runs
 checkRequirements
 showDisclaimer
 prepare

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -424,7 +424,10 @@ lockdownDbUser() {
 # Disable the repo and lock the versions. 
 disableRepo() {
   echo -n "👮 Disabling autoupdates                 ... "
-  sudo dnf config-manager --disable opennms-repo-stable-*
+  # Rocky 10 ships dnf5 without the config-manager plugin; fall back to
+  # disabling the repo file directly.
+  sudo dnf config-manager --disable "opennms-repo-stable-*" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}" \
+    || sudo sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/opennms-repo-stable-*.repo 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }
 

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -28,7 +28,11 @@ case "${SCRIPT}" in
     PG_SERVICE="postgresql"
     ;;
   bootstrap-yum.sh)
-    PREREQS="dnf install -y systemd sudo hostname && dnf clean all"
+    # chmod /etc/shadow: EL ships it with mode 0000, so unix_chkpwd needs
+    # CAP_DAC_OVERRIDE, which the Ubuntu host's AppArmor unix-chkpwd profile
+    # denies inside containers and sudo fails with a PAM error. Mode 0640
+    # lets root read it without the capability.
+    PREREQS="dnf install -y systemd sudo hostname && dnf clean all && chmod 0640 /etc/shadow"
     # The EL unit name carries the version; derive it from the script so a
     # version bump there cannot drift from this check.
     PG_SERVICE="postgresql-$(sed -n 's/^PSQL_MAX_VERSION=//p' bootstrap-yum.sh)"

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Run a bootstrap script unattended inside a systemd container and verify
+# the OpenNMS installation. Used by CI and for local reproduction:
+#
+#   tests/integration-test.sh debian:trixie bootstrap-debian.sh
+#   tests/integration-test.sh almalinux:9 bootstrap-yum.sh
+
+set -euo pipefail
+
+IMAGE="${1:?Usage: ${0} <image> <bootstrap-script>}"
+SCRIPT="${2:?Usage: ${0} <image> <bootstrap-script>}"
+# Unique container name so concurrent runs (e.g. deb and rpm in parallel)
+# do not collide; one test image per script family to reuse the build cache.
+CONTAINER="opennms-install-test-$$"
+TEST_IMAGE="opennms-install-test-${SCRIPT%.sh}"
+
+# The plain distribution images do not ship everything a real host has:
+# systemd (Debian/Ubuntu images boot without it), sudo and lsb-release are
+# hard requirements of the bootstrap scripts, and hostname provides
+# "hostname -I" used to determine the IP address on EL.
+case "${SCRIPT}" in
+  bootstrap-debian.sh)
+    PREREQS="apt-get update && apt-get install -y systemd systemd-sysv sudo lsb-release && apt-get clean"
+    PG_SERVICE="postgresql"
+    ;;
+  bootstrap-yum.sh)
+    PREREQS="dnf install -y systemd sudo hostname && dnf clean all"
+    # The EL unit name carries the version; derive it from the script so a
+    # version bump there cannot drift from this check.
+    PG_SERVICE="postgresql-$(sed -n 's/^PSQL_MAX_VERSION=//p' bootstrap-yum.sh)"
+    ;;
+  *)
+    echo "Unknown bootstrap script: ${SCRIPT}" >&2
+    exit 1
+    ;;
+esac
+
+cleanup() {
+  status="${?}"
+  if [[ "${status}" -ne 0 ]]; then
+    echo "=== Installer log ==="
+    docker exec "${CONTAINER}" cat /workspace/bootstrap.log 2>/dev/null || true
+    echo "=== Systemd journal ==="
+    docker exec "${CONTAINER}" journalctl -n 200 --no-pager 2>/dev/null || true
+  fi
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+  exit "${status}"
+}
+trap cleanup EXIT
+
+echo "== Build test image from ${IMAGE}"
+docker build -t "${TEST_IMAGE}" - <<EOF
+FROM ${IMAGE}
+RUN ${PREREQS}
+CMD ["/sbin/init"]
+EOF
+
+echo "== Launch systemd container"
+docker run -d \
+  --name "${CONTAINER}" \
+  --privileged \
+  --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+  --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+  "${TEST_IMAGE}" /sbin/init
+
+echo "== Copy installer into container"
+docker exec "${CONTAINER}" mkdir -p /workspace
+docker cp . "${CONTAINER}:/workspace/"
+
+echo "== Run ${SCRIPT}"
+docker exec \
+  -e ONMS_UNATTENDED=yes \
+  -e POSTGRES_PASS=bootstrap-ci \
+  "${CONTAINER}" bash -c "cd /workspace && bash ${SCRIPT}"
+
+echo "== Verify installation"
+echo -n "PostgreSQL service: "
+docker exec "${CONTAINER}" systemctl is-active "${PG_SERVICE}"
+echo -n "OpenNMS service: "
+docker exec "${CONTAINER}" systemctl is-active opennms
+docker exec "${CONTAINER}" curl -f -s -o /dev/null -w "Web UI HTTP status: %{http_code}\n" http://localhost:8980/opennms/


### PR DESCRIPTION
Add an automated integration test matrix workflow in GitHub Actions validating installation scripts against 8 Linux distribution targets.

Supersedes #62: GitHub never created check suites for that PR despite multiple pushes and a close/reopen, while probe PRs with the identical workflow file triggered fine, so the PR object itself was broken.

### Target OS Matrix
- **DEB Family**: Debian 13 (Trixie), Ubuntu 24.04 LTS
- **RPM Family**: CentOS Stream 9, CentOS Stream 10, AlmaLinux 9, AlmaLinux 10, Rocky Linux 9, Rocky Linux 10

### Highlights
- Single matrix job driven through `make integration-test IMAGE=... SCRIPT=...`, reproducible locally with the same command.
- Shared harness `tests/integration-test.sh` layers systemd, sudo and lsb-release onto the vanilla target image and boots it with `--cgroupns=host`.
- Bootstrap scripts gain an unattended mode (`ONMS_UNATTENDED=yes` with env-driven credentials) plus installer fixes surfaced by the end-to-end runs (curl-minimal conflict, PGDG arch detection, PostgreSQL cluster start, dash-broken `scvcli` workaround).
- Validates PostgreSQL and OpenNMS service status and the web UI response on HTTP port 8980, dumping installer logs and journals on failure.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)