### PR TITLE
ci: add lint gate, harden workflow, configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,10 +9,37 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+          sudo mv ./actionlint /usr/local/bin/actionlint
+
+      - name: Run linters
+        run: make lint
+
   integration-test:
     name: "${{ matrix.distro }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +71,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Run integration test
         run: make integration-test IMAGE="${{ matrix.image }}" SCRIPT="${{ matrix.script }}"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
           sudo mv ./actionlint /usr/local/bin/actionlint
 
       - name: Run linters
@@ -76,3 +76,20 @@ jobs:
 
       - name: Run integration test
         run: make integration-test IMAGE="${{ matrix.image }}" SCRIPT="${{ matrix.script }}"
+
+  # Single aggregate check for branch protection: requiring this one context
+  # survives matrix renames and additions.
+  gate:
+    name: "Gate"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [lint, integration-test]
+    if: always()
+    steps:
+      - name: Fail unless all gated jobs succeeded
+        run: |
+          echo "lint: ${{ needs.lint.result }}"
+          echo "integration-test: ${{ needs.integration-test.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.integration-test.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@
 IMAGE ?= debian:trixie
 SCRIPT ?= bootstrap-debian.sh
 
+.PHONY: lint
+lint:
+	shellcheck -S warning bootstrap-debian.sh bootstrap-yum.sh tests/integration-test.sh
+	actionlint
+
 .PHONY: integration-test
 integration-test:
 	tests/integration-test.sh "$(IMAGE)" "$(SCRIPT)"


### PR DESCRIPTION
Audit batch 1 (#66).

- `make lint` runs shellcheck and actionlint; a new **Lint** job gates the integration matrix, so the checks that caught real bugs during #65 now run on every PR instead of by hand.
- Workflow hardening: least-privilege `permissions` block, `concurrency` with cancel-in-progress, `timeout-minutes` on all jobs, runner pinned to `ubuntu-24.04` (freezes the AppArmor unix-chkpwd behavior diagnosed in #65), `persist-credentials: false` on checkout.
- Dependabot config for the `github-actions` ecosystem keeps SHA pins and version comments current (labels PRs `dependencies`).

Note for after merge: branch protection should additionally require the new **Lint** check context.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)