### PR TITLE
docs: add contribution, security, release and support documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: The installer failed or produced a broken OpenNMS setup
+labels: ["bug", "triage"]
+body:
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: Distribution and version the script ran on
+      placeholder: "AlmaLinux 9.4, x86_64"
+    validations:
+      required: true
+  - type: dropdown
+    id: script
+    attributes:
+      label: Script
+      options:
+        - bootstrap-debian.sh
+        - bootstrap-yum.sh
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: log
+    attributes:
+      label: bootstrap.log excerpt
+      description: Relevant lines from bootstrap.log in the directory you ran the script from
+      render: text

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,18 @@
+name: Enhancement
+description: Suggest an improvement to the installer
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing or awkward today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should the installer do instead?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+Closes #<issue>
+
+## Checklist
+
+- [ ] `make lint` passes
+- [ ] Tested with `make integration-test` on at least one affected distribution
+- [ ] Commits are signed off (`git commit -s`); AI-assisted commits carry an `Assisted-by` trailer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,4 @@ CI (`integration-tests.yml`) runs lint plus an 8-distro matrix; branch protectio
 - OpenNMS `scvcli` uses the bashism `$(<java.conf)` under `#!/bin/sh` and breaks on dash; `bootstrap-debian.sh` must invoke it via `bash`.
 - EL minimal images ship `curl-minimal`, which conflicts with `curl`; keep `--allowerasing`.
 - Debian/Ubuntu library images have no systemd; the harness builds a throwaway image layering it in and boots with `--privileged --cgroupns=host`.
-- `dnf config-manager` is unavailable on EL10 images (no dnf-plugins-core); the scripts fall back to sed on the repo file.
+- `dnf config-manager` is missing on some EL10 images (Rocky 10 ships dnf5 without the plugin); the scripts fall back to sed on the repo file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent guide
+
+Bootstrap scripts that install OpenNMS Horizon on DEB (Debian/Ubuntu) and RPM (EL9/EL10) systems.
+Two entry points: `bootstrap-debian.sh` and `bootstrap-yum.sh`; shared test harness in `tests/integration-test.sh`.
+
+## Commands
+
+```bash
+make lint                                              # shellcheck + actionlint
+make integration-test IMAGE=debian:trixie SCRIPT=bootstrap-debian.sh
+make integration-test IMAGE=almalinux:9 SCRIPT=bootstrap-yum.sh
+```
+
+A full integration test installs OpenNMS in a systemd container and takes 3-15 minutes.
+CI (`integration-tests.yml`) runs lint plus an 8-distro matrix; branch protection requires the aggregate `Gate` check.
+
+## Conventions
+
+- Conventional Commits; every commit signed off (`git commit -s`) plus `Assisted-by: <Agent>:<model>` trailer for AI-assisted work (see CONTRIBUTING.md).
+- PRs start from an issue and close it with `Closes #N`; merges are merge commits (squash/rebase disabled).
+- Shell: bash with `set -eEuo pipefail`; step output pattern is `echo -n "label ... "` + `checkError "${?}"`; errors append to `bootstrap.log`.
+- Actions are SHA-pinned with a full-semver comment; CI invokes make targets, never tools directly.
+
+## Gotchas
+
+- The scripts are interactive by default; CI and automation set `ONMS_UNATTENDED=yes` and pass `POSTGRES_PASS` (plus optional `DB_NAME`/`DB_USER`/`DB_PASS`) via environment.
+- EL9 images ship `/etc/shadow` with mode 000; Ubuntu 24.04 hosts (GitHub runners) confine `unix_chkpwd` via AppArmor so sudo breaks unless the test image runs `chmod 0640 /etc/shadow` — do not remove that from the harness.
+- OpenNMS `scvcli` uses the bashism `$(<java.conf)` under `#!/bin/sh` and breaks on dash; `bootstrap-debian.sh` must invoke it via `bash`.
+- EL minimal images ship `curl-minimal`, which conflicts with `curl`; keep `--allowerasing`.
+- Debian/Ubuntu library images have no systemd; the harness builds a throwaway image layering it in and boots with `--privileged --cgroupns=host`.
+- `dnf config-manager` is unavailable on EL10 images (no dnf-plugins-core); the scripts fall back to sed on the repo file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ronny@no42.org.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for helping to improve the OpenNMS Quick Installer.
+
+## Workflow
+
+Work starts from a GitHub issue.
+Open one describing the bug or enhancement before you send a pull request, and reference it from the PR with a closing keyword (`Closes #123`).
+Pull requests are merged with a merge commit, so keep your branch history clean and meaningful.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>[scope]: <description>` with types like `feat`, `fix`, `docs`, `ci`, `chore`.
+
+## Developer Certificate of Origin (DCO)
+
+Every commit must be signed off (`git commit -s`), adding a `Signed-off-by:` trailer with your real name and email.
+The sign-off certifies the [DCO](https://developercertificate.org/): you have the right to submit the work under this project's license.
+
+## AI-assisted contributions
+
+AI assistance is welcome and must be disclosed.
+Commits created with AI assistance carry an additional trailer naming the agent and model, before the sign-off:
+
+```
+Assisted-by: <Agent>:<model>
+Signed-off-by: Your Name <you@example.org>
+```
+
+The human signer remains responsible for reviewing the changes and for license compliance.
+The `Signed-off-by` identity is always a human, never an AI.
+
+## Testing your changes
+
+```bash
+make lint                                              # shellcheck + actionlint
+make integration-test IMAGE=debian:trixie SCRIPT=bootstrap-debian.sh
+make integration-test IMAGE=almalinux:9 SCRIPT=bootstrap-yum.sh
+```
+
+The integration test boots a systemd container, runs the bootstrap script unattended, and verifies the PostgreSQL and OpenNMS services plus the web UI.
+CI runs the same targets across eight distributions; the `Gate` check must pass before merge.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # 🚀 OpenNMS Quick Installer ✨
 
+[![Integration Tests](https://github.com/opennms-forge/opennms-install/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/opennms-forge/opennms-install/actions/workflows/integration-tests.yml)
+[![Latest release](https://img.shields.io/github/v/release/opennms-forge/opennms-install)](https://github.com/opennms-forge/opennms-install/releases/latest)
+[![License](https://img.shields.io/github/license/opennms-forge/opennms-install)](LICENSE)
+
 This script is a convenient bootstrap script to install OpenNMS on Debian or CentOS systems.
 The script executes the steps documented in [Installation and Configuration guide](https://docs.opennms.com/horizon/latest/deployment/core/getting-started.html).
 
@@ -52,3 +56,9 @@ You can find us at:
 
 * Public OpenNMS [Mattermost Chat](https://chat.opennms.com/opennms/channels/opennms-discussion)
 * If you have longer discussions to share ideas, use our [OpenNMS Discourse](https://opennms.discourse.group) and tag your post with `opennms-installer`
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute, [SUPPORT.md](SUPPORT.md) for where to ask questions, and [RELEASING.md](RELEASING.md) for how releases are cut.
+
+## 📜 License
+
+This project is licensed under the [GNU General Public License v3.0](LICENSE).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,21 @@
+# Releasing
+
+Releases mark tested states of the bootstrap scripts.
+There is no build artifact: users consume the scripts from the tag or from `main`.
+
+## Versioning
+
+Tags use an `X.Y` scheme (for example `2.5`).
+Classify the commits since the last tag by Conventional Commit type to pick the next version: breaking changes bump `X`, everything else bumps `Y`.
+
+## Procedure
+
+1. Ensure `main` is green: the `Gate` check on the latest run must pass.
+2. Pick the version from the commits since the last tag (`git describe --tags --abbrev=0`).
+3. Tag the release: `git tag -a <X.Y> -m "<X.Y>" && git push origin <X.Y>`.
+4. Create a GitHub Release on the tag with curated notes: user-facing highlights and fixes with issue/PR links, no raw commit dump, chore/CI noise collapsed or omitted.
+
+## Planned
+
+A tag-triggered release workflow with checksums, cosign signatures, and an SBOM is tracked in [#70](https://github.com/opennms-forge/opennms-install/issues/70).
+This file changes in the same PR that lands it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via GitHub:
+[Report a vulnerability](https://github.com/opennms-forge/opennms-install/security/advisories/new).
+
+Do not open a public issue for security problems.
+You can expect an initial response within a week.
+
+## Scope
+
+This repository contains bootstrap scripts that install OpenNMS Horizon.
+For vulnerabilities in OpenNMS itself, follow the [OpenNMS security policy](https://github.com/OpenNMS/opennms/security/policy) instead.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,6 @@
+# Support
+
+- Questions and discussion: the public OpenNMS [Mattermost chat](https://chat.opennms.com/opennms/channels/opennms-discussion) or [OpenNMS Discourse](https://opennms.discourse.group) (tag your post with `opennms-installer`).
+- Bugs and feature requests for the installer: [GitHub issues](https://github.com/opennms-forge/opennms-install/issues).
+- Security reports: see [SECURITY.md](SECURITY.md) — never a public issue.
+- Help with OpenNMS itself (not the installer): the [OpenNMS documentation](https://docs.opennms.com/) and the channels above.


### PR DESCRIPTION
Audit batch 3 (#69).

- **CONTRIBUTING.md** — issue-first workflow, Conventional Commits, DCO sign-off, AI-assistance policy (`Assisted-by` trailer, human signer responsible), test commands.
- **SECURITY.md** — points at the now-enabled private vulnerability reporting; scopes product vulnerabilities to the OpenNMS policy.
- **RELEASING.md** — documents the current tag-based process accurately; the signed pipeline is tracked in #70 and this file changes in that PR.
- **AGENTS.md** + one-line **CLAUDE.md** pointer — make targets, conventions, and the container gotchas from #65 (AppArmor unix_chkpwd, scvcli dash bashism, curl-minimal, systemd images).
- **README** — CI/release/license badges under the title, doc links, License section.
- **Templates** — bug/enhancement issue forms (auto-labeled `triage`), PR template with `Closes #` and checklist.
- **CODE_OF_CONDUCT.md** (Contributor Covenant 2.1) and **SUPPORT.md**.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)