### PR TITLE
ci: add tag-triggered release pipeline with signing and SBOM

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Lets the release workflow reuse these quality gates instead of
+  # duplicating them.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Release
+
+on:
+  push:
+    tags: [ "v*.*.*" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: "Quality gates"
+    uses: ./.github/workflows/integration-tests.yml
+
+  release:
+    name: "Draft release"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: gate
+    permissions:
+      contents: write      # create the draft release and upload assets
+      id-token: write      # cosign keyless signing
+      attestations: write  # build provenance
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Assemble artifacts
+        run: |
+          mkdir -p dist
+          cp bootstrap-debian.sh bootstrap-yum.sh dist/
+          cd dist
+          sha256sum bootstrap-debian.sh bootstrap-yum.sh > SHA256SUMS
+
+      - name: Sign checksums with cosign keyless
+        run: |
+          cosign sign-blob --yes \
+            --output-signature dist/SHA256SUMS.sig \
+            --output-certificate dist/SHA256SUMS.pem \
+            dist/SHA256SUMS
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: dist/sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-path: |
+            dist/bootstrap-debian.sh
+            dist/bootstrap-yum.sh
+            dist/SHA256SUMS
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          PRERELEASE=""
+          case "${TAG}" in
+            *-*) PRERELEASE="--prerelease" ;;
+          esac
+          gh release create "${TAG}" --draft --verify-tag --title "${TAG}" ${PRERELEASE} dist/*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,21 +1,42 @@
 # Releasing
 
 Releases mark tested states of the bootstrap scripts.
-There is no build artifact: users consume the scripts from the tag or from `main`.
+Pushing a version tag triggers the Release workflow, which re-runs the quality gates and creates a **draft** GitHub Release with the scripts, a checksums file, a cosign signature, an SBOM, and build provenance attached.
 
 ## Versioning
 
-Tags use an `X.Y` scheme (for example `2.5`).
-Classify the commits since the last tag by Conventional Commit type to pick the next version: breaking changes bump `X`, everything else bumps `Y`.
+Tags follow SemVer with a `v` prefix: `vX.Y.Z` (releases up to `2.5` used a bare `X.Y` scheme).
+Classify the commits since the last tag by Conventional Commit type: `BREAKING CHANGE`/`!` bumps major, `feat` bumps minor, everything else bumps patch.
+Prerelease tags (`vX.Y.Z-rc1`) are marked as prereleases automatically and never become the latest release.
 
 ## Procedure
 
 1. Ensure `main` is green: the `Gate` check on the latest run must pass.
-2. Pick the version from the commits since the last tag (`git describe --tags --abbrev=0`).
-3. Tag the release: `git tag -a <X.Y> -m "<X.Y>" && git push origin <X.Y>`.
-4. Create a GitHub Release on the tag with curated notes: user-facing highlights and fixes with issue/PR links, no raw commit dump, chore/CI noise collapsed or omitted.
+2. Find the last tag (`git describe --tags --abbrev=0`) and pick the next version from the commits since then.
+3. Tag and push: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
+4. The Release workflow runs the full quality gates, then creates the draft release with artifacts.
+   Do not create the release by hand first.
+5. Curate the release notes: user-facing highlights and fixes with issue/PR links, breaking changes with a migration path, no raw commit dump, chore/CI noise omitted.
+6. Publish: `gh release edit vX.Y.Z --notes-file notes.md --draft=false`.
 
-## Planned
+## Verifying artifacts
 
-A tag-triggered release workflow with checksums, cosign signatures, and an SBOM is tracked in [#70](https://github.com/opennms-forge/opennms-install/issues/70).
-This file changes in the same PR that lands it.
+Verify the checksums file signature and then the scripts against it:
+
+```bash
+cosign verify-blob \
+  --certificate SHA256SUMS.pem \
+  --signature SHA256SUMS.sig \
+  --certificate-identity-regexp 'https://github.com/opennms-forge/opennms-install/\.github/workflows/release\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+Verify build provenance:
+
+```bash
+gh attestation verify bootstrap-debian.sh --repo opennms-forge/opennms-install
+```
+
+If the pipeline changes, this file changes in the same PR.


### PR DESCRIPTION
Audit batch 4 (#70), implementing the vX.Y.Z decision.

- **release.yml**: `v*.*.*` tag push → quality gates (reused via `workflow_call` on the integration tests workflow, defined once) → draft release with `bootstrap-debian.sh`, `bootstrap-yum.sh`, `SHA256SUMS` + cosign keyless signature (`.sig`/`.pem`), SPDX SBOM, and SLSA build provenance. Prerelease tags (`-rc1`) marked automatically. Least-privilege permissions, `cancel-in-progress: false`, pinned runner and SHA-pinned actions with full-semver comments.
- **RELEASING.md**: rewritten for the `vX.Y.Z` SemVer scheme (bare `X.Y` retired after 2.5), with the tag procedure, curated-notes rule, and `cosign verify-blob` / `gh attestation verify` commands.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)