### PR TITLE
feat!: pin certified combo of PostgreSQL 18 and OpenNMS Horizon 36.0.3

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,11 @@ on:
   # Lets the release workflow reuse these quality gates instead of
   # duplicating them.
   workflow_call:
+  # Weekly expiry alarm for the certified-combo pins: debian.opennms.org
+  # serves only the newest release, so the deb pin breaks when upstream
+  # publishes and this run fails until the pin is bumped.
+  schedule:
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Two entry points: `bootstrap-debian.sh` and `bootstrap-yum.sh`; shared test harn
 ## Commands
 
 ```bash
-make lint                                              # shellcheck + actionlint
+make lint                                              # shellcheck + actionlint + version-consistency check
 make integration-test IMAGE=debian:trixie SCRIPT=bootstrap-debian.sh
 make integration-test IMAGE=almalinux:9 SCRIPT=bootstrap-yum.sh
 ```
@@ -29,3 +29,6 @@ CI (`integration-tests.yml`) runs lint plus an 8-distro matrix; branch protectio
 - EL minimal images ship `curl-minimal`, which conflicts with `curl`; keep `--allowerasing`.
 - Debian/Ubuntu library images have no systemd; the harness builds a throwaway image layering it in and boots with `--privileged --cgroupns=host`.
 - `dnf config-manager` is missing on some EL10 images (Rocky 10 ships dnf5 without the plugin); the scripts fall back to sed on the repo file.
+- The scripts pin a certified combo (`ONMS_VERSION`, `PSQL_VERSION`, mirrored in the README badges; `make lint` enforces agreement).
+  Deb pins expire when upstream releases because debian.opennms.org serves only the newest version; rpm pins do not (yum.opennms.org keeps history).
+  Renovate bumps the Horizon pin; see RELEASING.md for the procedure.

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ SCRIPT ?= bootstrap-debian.sh
 
 .PHONY: lint
 lint:
-	shellcheck -S warning bootstrap-debian.sh bootstrap-yum.sh tests/integration-test.sh
+	shellcheck -S warning bootstrap-debian.sh bootstrap-yum.sh tests/integration-test.sh tests/check-versions.sh
 	actionlint
+	tests/check-versions.sh
 
 .PHONY: integration-test
 integration-test:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 [![Integration Tests](https://github.com/opennms-forge/opennms-install/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/opennms-forge/opennms-install/actions/workflows/integration-tests.yml)
 [![Latest release](https://img.shields.io/github/v/release/opennms-forge/opennms-install)](https://github.com/opennms-forge/opennms-install/releases/latest)
 [![License](https://img.shields.io/github/license/opennms-forge/opennms-install)](LICENSE)
+[![OpenNMS Horizon](https://img.shields.io/badge/OpenNMS_Horizon-36.0.3-4c9d45)](https://docs.opennms.com/horizon/36/releasenotes/whatsnew.html)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18-336791)](https://docs.opennms.com/horizon/36/deployment/core/system-requirements.html)
 
 This script is a convenient bootstrap script to install OpenNMS on Debian or CentOS systems.
 The script executes the steps documented in [Installation and Configuration guide](https://docs.opennms.com/horizon/latest/deployment/core/getting-started.html).
 
-The script is tested with:
+The scripts install a certified combination, shown in the badges above: the pinned OpenNMS Horizon and PostgreSQL versions are exactly what the CI matrix validates.
+The certified combo is tested on:
 
 * Ubuntu 24.04 (Noble Numbat) x86_64
 * Debian 13 (Trixie) x86_64
@@ -24,7 +27,7 @@ We have also started to work on Ansible roles for the Ubuntu-based operating sys
 
 ## 🎯 Scope
 
-* Bootstrap a single-node OpenNMS system on RPM or DEB-based systems quickly with the latest stable release
+* Bootstrap a single-node OpenNMS system on RPM or DEB-based systems quickly with the certified stable release shown in the badges
 * Installation procedure closely following the best practices from our official docs
 * Scripts don't deal with existing installations or upgrades
 * Scripts don't configure or install Minions, Sentinels, or distributed time series storage like Cortex.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,6 +19,18 @@ Prerelease tags (`vX.Y.Z-rc1`) are marked as prereleases automatically and never
 5. Curate the release notes: user-facing highlights and fixes with issue/PR links, breaking changes with a migration path, no raw commit dump, chore/CI noise omitted.
 6. Publish: `gh release edit vX.Y.Z --notes-file notes.md --draft=false`.
 
+## Certified-combo pins
+
+The bootstrap scripts pin a certified combination: `ONMS_VERSION` (OpenNMS Horizon) and `PSQL_VERSION` (PostgreSQL), defined as constants at the top of both scripts and shown as README badges.
+The two pins bump independently: Horizon on its release cadence (second Wednesday of the month), PostgreSQL rarely and only within the window Horizon supports.
+
+- Renovate authors Horizon bump PRs automatically (`renovate.json` watches OpenNMS/opennms releases) and updates both scripts and the README badge with the same version.
+- PostgreSQL bumps are manual: change `PSQL_VERSION` in both scripts and the README badge, and check the new version is inside Horizon's supported range first.
+- `make lint` fails when scripts and badges disagree, so partial bumps cannot merge.
+- A green 8-distro matrix (`Gate`) on the bump PR is the re-certification; merging the PR certifies the new combo.
+- debian.opennms.org serves only the newest release, so the deb pin breaks when upstream publishes: the weekly scheduled Integration Tests run is the expiry alarm.
+  A failed scheduled run on `main` means a bump PR is due.
+
 ## Verifying artifacts
 
 Verify the checksums file signature and then the scripts against it:

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -335,7 +335,7 @@ installOnmsApp() {
   # --no-install-recommends: opennms recommends openjdk-21, which apt would
   # install next to the Temurin JDK because temurin-21-jdk does not provide
   # any name in the recommends list, see issue #48.
-  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms="${ONMS_VERSION}-1" opennms-webapp-hawtio="${ONMS_VERSION}-1" 2>>"${ERROR_LOG}"
+  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms="${ONMS_VERSION}-*" opennms-webapp-hawtio="${ONMS_VERSION}-*" 2>>"${ERROR_LOG}"
   sudo -u opennms "${OPENNMS_HOME}"/bin/runjava -s 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }

--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -28,7 +28,10 @@ ENDCOLOR="\e[0m"
 
 REQUIRED_SYSTEMS="Ubuntu|Debian"
 REQUIRED_JDK="21"
-PSQL_MAX_VERSION=15
+PSQL_VERSION=18
+# OpenNMS Horizon version of the certified combo. Deb and rpm installs pin
+# this exact version; bumping it requires a green CI matrix (re-certification).
+ONMS_VERSION=36.0.3
 IP_ADDRESS=$(hostname -I | awk '{print $1}') # export the address so it can also be used in the timeout command
 
 # Error codes
@@ -302,7 +305,7 @@ installPostgres() {
   sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "📦 Install PostgreSQL database           ... "
-  sudo apt-get install -y postgresql-${PSQL_MAX_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo apt-get install -y postgresql-${PSQL_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   # The postinst normally starts the cluster; make sure it runs on systems
   # where deferred service starts are policy (e.g. containers).
@@ -332,7 +335,7 @@ installOnmsApp() {
   # --no-install-recommends: opennms recommends openjdk-21, which apt would
   # install next to the Temurin JDK because temurin-21-jdk does not provide
   # any name in the recommends list, see issue #48.
-  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms opennms-webapp-hawtio 2>>"${ERROR_LOG}"
+  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms="${ONMS_VERSION}-1" opennms-webapp-hawtio="${ONMS_VERSION}-1" 2>>"${ERROR_LOG}"
   sudo -u opennms "${OPENNMS_HOME}"/bin/runjava -s 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -30,7 +30,10 @@ REQUIRED_SYSTEMS="^(Red Hat Enterprise Linux|Rocky Linux|CentOS Stream|AlmaLinux
 REQUIRED_JDK="21"
 RELEASE_FILE="/etc/redhat-release"
 OS_MAJOR_VERSION=$(grep -oE '[0-9]+' /etc/redhat-release | head -1)
-PSQL_MAX_VERSION=15
+PSQL_VERSION=18
+# OpenNMS Horizon version of the certified combo. Deb and rpm installs pin
+# this exact version; bumping it requires a green CI matrix (re-certification).
+ONMS_VERSION=36.0.3
 IP_ADDRESS=$(hostname -I | awk '{print $1}') # export the address so it can also be used in the timeout command
 
 # Error codes
@@ -229,7 +232,7 @@ setDbCredentials() {
   sudo -i -u postgres psql -c "ALTER SYSTEM SET password_encryption = 'scram-sha-256';" 1>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "🔄 Restart PostgreSQL Server             ... "
-  sudo systemctl restart postgresql-${PSQL_MAX_VERSION} 1>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo systemctl restart postgresql-${PSQL_VERSION} 1>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "👩‍🔧 Create database and users             ... "
   {
@@ -273,8 +276,8 @@ installPostgres() {
   echo "📦 Add PostgreSQL repository             ... "
   sudo dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_MAJOR_VERSION}-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm"
   checkError "${?}"
-  echo -n "📦 Install PostgreSQL ${PSQL_MAX_VERSION} database        ... "
-  sudo dnf install -y postgresql${PSQL_MAX_VERSION}-server 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  echo -n "📦 Install PostgreSQL ${PSQL_VERSION} database        ... "
+  sudo dnf install -y postgresql${PSQL_VERSION}-server 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }
 
@@ -293,7 +296,7 @@ installOnmsRepo() {
 # Install the OpenNMS application from rpm repository
 installOnmsApp() {
   echo -n "📦 Install OpenNMS Horizon packages      ... "
-  sudo dnf -y install rrdtool jrrd2 jicmp jicmp6 opennms-core opennms-webapp-jetty opennms-webapp-hawtio 1>>"${ERROR_LOG}" 2>>${ERROR_LOG}
+  sudo dnf -y install rrdtool jrrd2 jicmp jicmp6 opennms-core-"${ONMS_VERSION}" opennms-webapp-jetty-"${ONMS_VERSION}" opennms-webapp-hawtio-"${ONMS_VERSION}" 1>>"${ERROR_LOG}" 2>>${ERROR_LOG}
   sudo -u opennms "${OPENNMS_HOME}"/bin/runjava -s 1>>"${ERROR_LOG}" 2>>${ERROR_LOG}
   checkError "${?}"
 }
@@ -365,13 +368,13 @@ setCredentials() {
 # Helper script to initialize the PostgreSQL database
 initializePostgres() {
   echo -n "👩‍🔧 PostgreSQL initialize                 ... "
-  sudo postgresql-${PSQL_MAX_VERSION}-setup initdb 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo postgresql-${PSQL_VERSION}-setup initdb 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "🚀 Start PostgreSQL database             ... "
-  sudo systemctl start postgresql-${PSQL_MAX_VERSION}
+  sudo systemctl start postgresql-${PSQL_VERSION}
   checkError "${?}"
   echo -n "🚀 PostgreSQL systemd enable             ... "
-  sudo systemctl enable postgresql-${PSQL_MAX_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo systemctl enable postgresql-${PSQL_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Scoped to the certified-combo Horizon pin only; Dependabot handles github-actions updates.",
+  "enabledManagers": ["custom.regex"],
+  "labels": ["dependencies"],
+  "schedule": ["before 8am on monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "One depName across both bootstrap scripts and the README badge so every location receives the identical X.Y.Z value.",
+      "managerFilePatterns": ["/^bootstrap-debian\\.sh$/", "/^bootstrap-yum\\.sh$/", "/^README\\.md$/"],
+      "matchStrings": [
+        "ONMS_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "OpenNMS_Horizon-(?<currentValue>\\d+\\.\\d+\\.\\d+)-"
+      ],
+      "depNameTemplate": "OpenNMS/opennms",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^opennms-(?<version>\\d+\\.\\d+\\.\\d+)-\\d+$",
+      "versioningTemplate": "semver"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Scoped to the certified-combo Horizon pin only; Dependabot handles github-actions updates.",
+  "description": "Scoped to the certified-combo Horizon pin only; Dependabot handles github-actions updates. Schedule: Renovate cron uses AND semantics for day-of-month and day-of-week, so '* * 8-14 * 3' is exactly the second Wednesday of the month, the Horizon release day. If a release slips past the window, trigger a run from the Dependency Dashboard.",
   "enabledManagers": ["custom.regex"],
   "labels": ["dependencies"],
-  "schedule": ["before 8am on monday"],
+  "schedule": ["* * 8-14 * 3"],
   "customManagers": [
     {
       "customType": "regex",

--- a/tests/check-versions.sh
+++ b/tests/check-versions.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Fail when the README badges disagree with the version constants in the
+# bootstrap scripts: the certified combo must be stated truthfully.
+
+set -euo pipefail
+
+fail=0
+for script in bootstrap-debian.sh bootstrap-yum.sh; do
+  onms=$(sed -n 's/^ONMS_VERSION=//p' "${script}")
+  psql=$(sed -n 's/^PSQL_VERSION=//p' "${script}")
+  if ! grep -qF "OpenNMS_Horizon-${onms}-" README.md; then
+    echo "README Horizon badge does not show ${onms} (ONMS_VERSION in ${script})" >&2
+    fail=1
+  fi
+  if ! grep -qF "PostgreSQL-${psql}-" README.md; then
+    echo "README PostgreSQL badge does not show ${psql} (PSQL_VERSION in ${script})" >&2
+    fail=1
+  fi
+done
+exit "${fail}"

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -35,7 +35,7 @@ case "${SCRIPT}" in
     PREREQS="dnf install -y systemd sudo hostname && dnf clean all && chmod 0640 /etc/shadow"
     # The EL unit name carries the version; derive it from the script so a
     # version bump there cannot drift from this check.
-    PG_SERVICE="postgresql-$(sed -n 's/^PSQL_MAX_VERSION=//p' bootstrap-yum.sh)"
+    PG_SERVICE="postgresql-$(sed -n 's/^PSQL_VERSION=//p' bootstrap-yum.sh)"
     ;;
   *)
     echo "Unknown bootstrap script: ${SCRIPT}" >&2


### PR DESCRIPTION
Pins the installer to a certified combination validated by the 8-distro matrix, replacing "whatever stable serves at install time".

## What changed

- `PSQL_VERSION=18` (renamed from `PSQL_MAX_VERSION`; PostgreSQL 18 is inside Horizon 36's supported window of 14.x-18.x)
- `ONMS_VERSION=36.0.3` pinned in both scripts: deb `opennms=${ONMS_VERSION}-1` (dependency tree is strictly version-locked at every level, verified against the Packages index), rpm `opennms-core-${ONMS_VERSION}` etc.; rrdtool/jicmp/jicmp6/jrrd2 stay floating
- README badges show the certified combo; `tests/check-versions.sh` in `make lint` fails when badges and script constants disagree (negative-tested)
- Weekly scheduled matrix run as the pin-expiry alarm: debian.opennms.org serves only the newest release, so the deb pin fails loudly when upstream publishes
- `renovate.json` (scoped to one custom regex manager, github-releases datasource on OpenNMS/opennms) authors bump PRs updating both scripts and the badge with the identical version; verified with a local Renovate dry run extracting all three locations. Dependabot keeps github-actions updates.

## Verification

- PGDG serves PostgreSQL 18 for all eight targets (EL9/EL10 x86_64+aarch64 repomd HTTP 200; `postgresql-18` in trixie/noble amd64+arm64 Packages)
- Local end-to-end installs green on both families: `debian:trixie` and `almalinux:9` (PostgreSQL 18 and OpenNMS services active, Web UI HTTP 302)
- `make lint` green (shellcheck, actionlint, version-consistency check)
- The green matrix on this PR is the first certification of the combo

## Follow-up (org admin, one click)

The Renovate app is installed on the org with "selected repositories"; add `opennms-install` to its selection so bump PRs start flowing.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)