### PR TITLE
fix(release): use the cosign v3 sigstore bundle when signing checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,11 @@ jobs:
           sha256sum bootstrap-debian.sh bootstrap-yum.sh > SHA256SUMS
 
       - name: Sign checksums with cosign keyless
+        # cosign v3 defaults to the sigstore bundle format; the former
+        # --output-signature/--output-certificate flags are deprecated no-ops.
         run: |
           cosign sign-blob --yes \
-            --output-signature dist/SHA256SUMS.sig \
-            --output-certificate dist/SHA256SUMS.pem \
+            --bundle dist/SHA256SUMS.sigstore.json \
             dist/SHA256SUMS
 
       - name: Generate SBOM

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,12 +33,11 @@ The two pins bump independently: Horizon on its release cadence (second Wednesda
 
 ## Verifying artifacts
 
-Verify the checksums file signature and then the scripts against it:
+Verify the checksums file signature (cosign v3 sigstore bundle) and then the scripts against it:
 
 ```bash
 cosign verify-blob \
-  --certificate SHA256SUMS.pem \
-  --signature SHA256SUMS.sig \
+  --bundle SHA256SUMS.sigstore.json \
   --certificate-identity-regexp 'https://github.com/opennms-forge/opennms-install/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS


### PR DESCRIPTION
The first run of the release pipeline (tag `v3.0.0`, run 31763995540) passed all quality gates but failed in the signing step: cosign v3 (via cosign-installer v4.1.2) defaults to the new sigstore bundle format, deprecates `--output-signature`/`--output-certificate` into no-ops, and errors with `create bundle file: open : no such file or directory` when no `--bundle` path is given.

- Sign with `--bundle dist/SHA256SUMS.sigstore.json` (single bundle asset containing signature and certificate)
- RELEASING.md verification updated to `cosign verify-blob --bundle ...`

After merge, the `v3.0.0` tag will be moved to the fixed commit and re-pushed (the workflow file is read from the tag's commit; the failed run created no release, so nothing published moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)