### PR TITLE
fix(debian): pass DEBIAN_FRONTEND through sudo to suppress debconf note

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -288,7 +288,10 @@ installJdk() {
   sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "📦 Install Temurin Java Development Kit  ... "
-  sudo apt-get install -y --no-install-recommends "temurin-${REQUIRED_JDK}-jdk" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  # sudo's env_reset strips the exported DEBIAN_FRONTEND, so pass it on the
+  # command line for every apt-get install, or debconf prompts (e.g. the
+  # opennms-db/noinstall note) block the bootstrap on real terminals, issue #32.
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "temurin-${REQUIRED_JDK}-jdk" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }
 
@@ -305,7 +308,7 @@ installPostgres() {
   sudo apt-get update 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   echo -n "📦 Install PostgreSQL database           ... "
-  sudo apt-get install -y postgresql-${PSQL_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${PSQL_VERSION} 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
   # The postinst normally starts the cluster; make sure it runs on systems
   # where deferred service starts are policy (e.g. containers).
@@ -335,7 +338,7 @@ installOnmsApp() {
   # --no-install-recommends: opennms recommends openjdk-21, which apt would
   # install next to the Temurin JDK because temurin-21-jdk does not provide
   # any name in the recommends list, see issue #48.
-  sudo apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms="${ONMS_VERSION}-*" opennms-webapp-hawtio="${ONMS_VERSION}-*" 2>>"${ERROR_LOG}"
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends rrdtool jrrd2 jicmp jicmp6 opennms="${ONMS_VERSION}-*" opennms-webapp-hawtio="${ONMS_VERSION}-*" 2>>"${ERROR_LOG}"
   sudo -u opennms "${OPENNMS_HOME}"/bin/runjava -s 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
   checkError "${?}"
 }


### PR DESCRIPTION
Closes #32

## Problem
`bootstrap-debian.sh` exports `DEBIAN_FRONTEND=noninteractive` at the top, but every apt call runs through `sudo`, whose default `env_reset` policy strips the variable before apt/dpkg/debconf see it. On a real terminal the `opennms-db/noinstall` debconf note (a `note`-type template shown by the package's `.config` script on every install) pops up mid-bootstrap and blocks until the user presses OK, telling them to run `bin/install` manually, which the bootstrap already does itself.

## Fix
Prefix `DEBIAN_FRONTEND=noninteractive` on the three `sudo apt-get install` invocations (Temurin JDK, PostgreSQL, OpenNMS packages) so the noninteractive frontend actually reaches the dpkg maintainer scripts. Only the install lines need it; `apt-get update` runs no maintainer scripts.

## Verification
Empirical check of the mechanism on `debian:trixie`: `sudo env` drops the exported variable (`env_reset`), while `sudo DEBIAN_FRONTEND=noninteractive env` carries it through. The popup itself is only reproducible with a TTY, which is also why CI never hung: without a terminal, debconf's dialog frontend fails and falls back to noninteractive on its own, so the matrix cannot regression-test the popup directly.

- `make lint` passes
- `make integration-test IMAGE=debian:trixie SCRIPT=bootstrap-debian.sh` green: exit 0, PostgreSQL active, OpenNMS active, web UI HTTP 302

The upstream half of #32 (the note's text says to run `bin/install` without flags, which only prints "Nothing to do.") is out of scope here and will be filed against OpenNMS/opennms separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)