### PR TITLE
docs(readme): install from the latest release with copy-paste commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,30 @@ We have also started to work on Ansible roles for the Ubuntu-based operating sys
 
 ## 🕹️ Usage
 
-Download the script to your system.
+Download the script for your distro family from the latest release and run it.
 
-Execute on a CentOS-based system
+On an RPM-based system (AlmaLinux, Rocky Linux, CentOS Stream 9/10):
+
 ```bash
+curl -fsSLO https://github.com/opennms-forge/opennms-install/releases/latest/download/bootstrap-yum.sh
 sudo bash bootstrap-yum.sh
 ```
 
-Execute on a Debian-based system
+On a DEB-based system (Debian, Ubuntu):
+
 ```bash
+curl -fsSLO https://github.com/opennms-forge/opennms-install/releases/latest/download/bootstrap-debian.sh
 sudo bash bootstrap-debian.sh
 ```
+
+Optionally, verify the download against the release checksums before running it:
+
+```bash
+curl -fsSLO https://github.com/opennms-forge/opennms-install/releases/latest/download/SHA256SUMS
+sha256sum -c --ignore-missing SHA256SUMS
+```
+
+For full signature and provenance verification with cosign, see [Verifying artifacts](RELEASING.md#verifying-artifacts) in RELEASING.md.
 
 ## 👋 Say hello
 You are very welcome to join us to make this repo a better place.


### PR DESCRIPTION
Closes #77

## What
Rewrites the README Usage section: per-family download-then-run blocks fetching `bootstrap-yum.sh` / `bootstrap-debian.sh` from the stable `releases/latest/download/` URLs, an optional checksum block (`sha256sum -c --ignore-missing SHA256SUMS`), a link to RELEASING.md's [Verifying artifacts](RELEASING.md#verifying-artifacts) for full cosign verification, and the dated "CentOS-based" wording replaced with the tested distro families.

## Decisions
Download-then-run rather than `curl | sudo bash`: the scripts prompt interactively on stdin (confirmation, Postgres password), and piping bypasses artifact verification. `--ignore-missing` because `SHA256SUMS` lists both scripts while a user downloads only one. The `latest/download` redirect serves the newest published release and never drafts or prereleases.

## Verification
All three blocks executed verbatim against the live v3.0.1 release: both scripts download (HTTP 200), the checksum check reports `OK` for present scripts, and with only one script on disk it passes without flagging the absent one. `make lint` green (README badge consistency included). The `#verifying-artifacts` anchor resolves (RELEASING.md line 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)