### PR TITLE
refactor(scripts): use stock Horizon 36 datasources config instead of forking the XML

### DIFF
--- a/bootstrap-debian.sh
+++ b/bootstrap-debian.sh
@@ -344,8 +344,11 @@ installOnmsApp() {
 }
 
 ####
-# Generate OpenNMS configuration file for accessing the PostgreSQL
-# Database with credentials
+# Provide the database connection settings for the stock Horizon 36
+# opennms-datasources.xml: it resolves credentials from the secure
+# credentials vault first (aliases postgres and postgres-admin) and the
+# database name from the OPENNMS_DBNAME environment variable. The
+# packaged file is left untouched.
 setCredentials() {
   echo ""
   echo -n "👩‍🔧 Create secure vault for Postgres      ... "
@@ -354,58 +357,13 @@ setCredentials() {
   sudo -u opennms bash "${OPENNMS_HOME}/bin/scvcli" set postgres "${DB_USER}" "${DB_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
   sudo -u opennms bash "${OPENNMS_HOME}/bin/scvcli" set postgres-admin "${POSTGRES_USER}" "${POSTGRES_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  echo -n "🔧 Generate OpenNMS database config      ... "
-  if [[ -f "${OPENNMS_HOME}"/etc/opennms-datasources.xml ]]; then
-    printf '<?xml version="1.0" encoding="UTF-8"?>
-<datasource-configuration xmlns:this="http://xmlns.opennms.org/xsd/config/opennms-datasources"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://xmlns.opennms.org/xsd/config/opennms-datasources
-  http://www.opennms.org/xsd/config/opennms-datasources.xsd ">
-
-  <connection-pool factory="org.opennms.core.db.HikariCPConnectionFactory"
-      idleTimeout="600"
-      loginTimeout="3"
-      minPool="25"
-      maxPool="50"
-      maxSize="50" />
-
-  <jdbc-data-source name="opennms"
-                    database-name="%s"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/%s"
-                    user-name="${scv:postgres:username}"
-                    password="${scv:postgres:password}" />
-
-  <jdbc-data-source name="opennms-admin"
-                    database-name="template1"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/template1"
-                    user-name="${scv:postgres-admin:username}"
-                    password="${scv:postgres-admin:password}">
-    <connection-pool idleTimeout="600"
-                     minPool="0"
-                     maxPool="10"
-                     maxSize="50" />
-  </jdbc-data-source>
-
-  <jdbc-data-source name="opennms-monitor"
-                    database-name="postgres"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/postgres"
-                    user-name="${scv:postgres-admin:username}"
-                    password="${scv:postgres-admin:password}">
-    <connection-pool idleTimeout="600"
-                     minPool="0"
-                     maxPool="10"
-                     maxSize="50" />
-  </jdbc-data-source>
-</datasource-configuration>' "${DB_NAME}" "${DB_NAME}" \
-  | sudo -u opennms tee "${OPENNMS_HOME}"/etc/opennms-datasources.xml 1>>/dev/null 2>>"${ERROR_LOG}"
+  echo -n "🔧 Set OpenNMS database name             ... "
+  # bin/install and the service wrapper source opennms.conf without
+  # set -a, so the variable must be exported to reach the JVM. Write as
+  # the opennms user: the installer validates etc/ for read/write by it.
+  printf '# Database name for the stock opennms-datasources.xml (set by opennms-install)\nexport OPENNMS_DBNAME="%s"\n' "${DB_NAME}" \
+  | sudo -u opennms tee -a "${OPENNMS_HOME}"/etc/opennms.conf 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  else
-    echo "No OpenNMS configuration found in ${OPENNMS_HOME}/etc"
-    exit "${E_ILLEGAL_ARGS}"
-  fi
 }
 
 ####

--- a/bootstrap-yum.sh
+++ b/bootstrap-yum.sh
@@ -302,66 +302,24 @@ installOnmsApp() {
 }
 
 ####
-# Generate OpenNMS configuration file for accessing the PostgreSQL
-# Database with credentials
+# Provide the database connection settings for the stock Horizon 36
+# opennms-datasources.xml: it resolves credentials from the secure
+# credentials vault first (aliases postgres and postgres-admin) and the
+# database name from the OPENNMS_DBNAME environment variable. The
+# packaged file is left untouched.
 setCredentials() {
   echo ""
   echo -n "👩‍🔧 Create secure vault for Postgres      ... "
   sudo -u opennms "${OPENNMS_HOME}/bin/scvcli" set postgres-admin "${POSTGRES_USER}" "${POSTGRES_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
   sudo -u opennms "${OPENNMS_HOME}/bin/scvcli" set postgres "${DB_USER}" "${DB_PASS}" 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  echo -n "🔧 Generate OpenNMS database config      ... "
-  if [[ -f "${OPENNMS_HOME}"/etc/opennms-datasources.xml ]]; then
-    printf '<?xml version="1.0" encoding="UTF-8"?>
-<datasource-configuration xmlns:this="http://xmlns.opennms.org/xsd/config/opennms-datasources"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://xmlns.opennms.org/xsd/config/opennms-datasources
-  http://www.opennms.org/xsd/config/opennms-datasources.xsd ">
-
-  <connection-pool factory="org.opennms.core.db.HikariCPConnectionFactory"
-      idleTimeout="600"
-      loginTimeout="3"
-      minPool="25"
-      maxPool="50"
-      maxSize="50" />
-
-  <jdbc-data-source name="opennms"
-                    database-name="%s"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/%s"
-                    user-name="${scv:postgres:username}"
-                    password="${scv:postgres:password}" />
-
-  <jdbc-data-source name="opennms-admin"
-                    database-name="template1"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/template1"
-                    user-name="${scv:postgres-admin:username}"
-                    password="${scv:postgres-admin:password}">
-    <connection-pool idleTimeout="600"
-                     minPool="0"
-                     maxPool="10"
-                     maxSize="50" />
-  </jdbc-data-source>
-
-  <jdbc-data-source name="opennms-monitor"
-                    database-name="postgres"
-                    class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://localhost:5432/postgres"
-                    user-name="${scv:postgres-admin:username}"
-                    password="${scv:postgres-admin:password}">
-    <connection-pool idleTimeout="600"
-                     minPool="0"
-                     maxPool="10"
-                     maxSize="50" />
-  </jdbc-data-source>
-</datasource-configuration>' "${DB_NAME}" "${DB_NAME}" \
-  | sudo -u opennms tee "${OPENNMS_HOME}"/etc/opennms-datasources.xml 1>>/dev/null 2>>"${ERROR_LOG}"
+  echo -n "🔧 Set OpenNMS database name             ... "
+  # bin/install and the service wrapper source opennms.conf without
+  # set -a, so the variable must be exported to reach the JVM. Write as
+  # the opennms user: the installer validates etc/ for read/write by it.
+  printf '# Database name for the stock opennms-datasources.xml (set by opennms-install)\nexport OPENNMS_DBNAME="%s"\n' "${DB_NAME}" \
+  | sudo -u opennms tee -a "${OPENNMS_HOME}"/etc/opennms.conf 1>/dev/null 2>>"${ERROR_LOG}"
   checkError "${?}"
-  else
-    echo "No OpenNMS configuration found in ${OPENNMS_HOME}/etc"
-    exit "${E_ILLEGAL_ARGS}"
-  fi
 }
 
 ####

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -26,6 +26,8 @@ case "${SCRIPT}" in
   bootstrap-debian.sh)
     PREREQS="apt-get update && apt-get install -y systemd systemd-sysv sudo lsb-release && apt-get clean"
     PG_SERVICE="postgresql"
+    # shellcheck disable=SC2016
+    DS_VERIFY='pkg="$(dpkg -S /opt/opennms/etc/opennms-datasources.xml | cut -d: -f1)"; ! dpkg --verify "${pkg}" | grep datasources'
     ;;
   bootstrap-yum.sh)
     # chmod /etc/shadow: EL ships it with mode 0000, so unix_chkpwd needs
@@ -36,6 +38,7 @@ case "${SCRIPT}" in
     # The EL unit name carries the version; derive it from the script so a
     # version bump there cannot drift from this check.
     PG_SERVICE="postgresql-$(sed -n 's/^PSQL_VERSION=//p' bootstrap-yum.sh)"
+    DS_VERIFY='! rpm -Vf /opt/opennms/etc/opennms-datasources.xml | grep datasources'
     ;;
   *)
     echo "Unknown bootstrap script: ${SCRIPT}" >&2
@@ -77,9 +80,15 @@ docker exec "${CONTAINER}" mkdir -p /workspace
 docker cp . "${CONTAINER}:/workspace/"
 
 echo "== Run ${SCRIPT}"
+# Custom database identifiers, all distinct from the stock defaults in the
+# Horizon datasources file (opennms/postgres), so a silent fallback to the
+# defaults cannot pass the install.
 docker exec \
   -e ONMS_UNATTENDED=yes \
   -e POSTGRES_PASS=bootstrap-ci \
+  -e DB_NAME=horizon \
+  -e DB_USER=horizon \
+  -e DB_PASS=bootstrap-ci-db \
   "${CONTAINER}" bash -c "cd /workspace && bash ${SCRIPT}"
 
 echo "== Verify installation"
@@ -88,3 +97,7 @@ docker exec "${CONTAINER}" systemctl is-active "${PG_SERVICE}"
 echo -n "OpenNMS service: "
 docker exec "${CONTAINER}" systemctl is-active opennms
 docker exec "${CONTAINER}" curl -f -s -o /dev/null -w "Web UI HTTP status: %{http_code}\n" http://localhost:8980/opennms/
+echo -n "Packaged datasources file pristine: "
+docker exec "${CONTAINER}" bash -c "${DS_VERIFY}" && echo "yes"
+echo -n "OPENNMS_DBNAME export in opennms.conf: "
+docker exec "${CONTAINER}" grep -c 'export OPENNMS_DBNAME="horizon"' /opt/opennms/etc/opennms.conf


### PR DESCRIPTION
Closes #79

## What
Deletes the ~50-line `opennms-datasources.xml` fork from `setCredentials` in both bootstrap scripts. The stock Horizon 36 file resolves everything through runtime interpolation chains: credentials from the secure credentials vault first (the exact `postgres`/`postgres-admin` aliases the bootstrap already populates via `scvcli`), env vars second, defaults last. The database name flows through `OPENNMS_DBNAME`, exported from `etc/opennms.conf`, which both `bin/install` and the service wrapper source. HikariCP is the compiled-in default pool factory since 36, so the fork's explicit factory pin was redundant too.

Net effect: `setCredentials` shrinks from ~60 lines to ~10, the packaged conffile stays pristine (no more modified-conffile prompts on package upgrades), and the stock SSL/pool env tunables the fork dropped are available again.

## Test coverage
The harness now runs every matrix image with non-default `DB_NAME=horizon`/`DB_USER=horizon`/`DB_PASS` (all distinct from the stock defaults, so a silent fallback cannot pass) and adds two assertions: the packaged datasources file verifies unmodified (`dpkg --verify` / `rpm -Vf`), and the `OPENNMS_DBNAME` export is present in `opennms.conf`.

## Verification
Local runs of `debian:trixie` and `almalinux:9` are green end to end with the custom identifiers: exit 0, PostgreSQL active, OpenNMS active, web UI 302, datasources pristine, export present.

One implementation finding worth noting for review: `opennms.conf` must be written as the `opennms` user — the installer's `FilesystemPermissionValidator` requires everything under `etc/` to be read/write by that account and aborts `install -dis` on a root-owned file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)