### PR TITLE
ci: run the full integration matrix on both x86_64 and arm64

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,15 +44,18 @@ jobs:
         run: make lint
 
   integration-test:
-    name: "${{ matrix.distro }}"
-    # Entries default to amd64; the ARM64 legs override via matrix.runner.
-    runs-on: ${{ matrix.runner || 'ubuntu-24.04' }}
+    name: "${{ matrix.config.distro }}${{ matrix.runner == 'ubuntu-24.04-arm' && ' (ARM64)' || '' }}"
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: lint
     strategy:
       fail-fast: false
+      # Cross product: every distro runs on both architectures (issue #46).
+      # The package repos ship arm64 builds of all native packages, so the
+      # certification claim is per distro AND per architecture.
       matrix:
-        include:
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        config:
           - distro: "Debian 13 (Trixie)"
             image: "debian:trixie"
             script: "bootstrap-debian.sh"
@@ -77,16 +80,6 @@ jobs:
           - distro: "Rocky Linux 10"
             image: "rockylinux/rockylinux:10"
             script: "bootstrap-yum.sh"
-          # One ARM64 leg per script family (issue #46): Ubuntu/deb is the
-          # original #45 jrrd2 failure case, AlmaLinux 10 represents EL.
-          - distro: "Ubuntu 24.04 LTS (ARM64)"
-            image: "ubuntu:24.04"
-            script: "bootstrap-debian.sh"
-            runner: "ubuntu-24.04-arm"
-          - distro: "AlmaLinux 10 (ARM64)"
-            image: "almalinux:10"
-            script: "bootstrap-yum.sh"
-            runner: "ubuntu-24.04-arm"
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -94,7 +87,7 @@ jobs:
           persist-credentials: false
 
       - name: Run integration test
-        run: make integration-test IMAGE="${{ matrix.image }}" SCRIPT="${{ matrix.script }}"
+        run: make integration-test IMAGE="${{ matrix.config.image }}" SCRIPT="${{ matrix.config.script }}"
 
   # Single aggregate check for branch protection: requiring this one context
   # survives matrix renames and additions.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ This script is a convenient bootstrap script to install OpenNMS on Debian or Cen
 The script executes the steps documented in [Installation and Configuration guide](https://docs.opennms.com/horizon/latest/deployment/core/getting-started.html).
 
 The scripts install a certified combination, shown in the badges above: the pinned OpenNMS Horizon and PostgreSQL versions are exactly what the CI matrix validates.
-The certified combo is tested on:
+The certified combo is tested on, each on x86_64 and arm64:
 
-* Ubuntu 24.04 (Noble Numbat) x86_64
-* Debian 13 (Trixie) x86_64
-* CentOS Stream 9/10 x86_64
-* Rocky Linux 9/10 x86_64
-* AlmaLinux 9/10 x86_64
+* Ubuntu 24.04 (Noble Numbat)
+* Debian 13 (Trixie)
+* CentOS Stream 9/10
+* Rocky Linux 9/10
+* AlmaLinux 9/10
+
+The OpenNMS package repositories ship arm64 builds of all native packages (jrrd2, jicmp, jicmp6), so the scripts work unmodified on both architectures; the CI matrix verifies every distro on both.
 
 [![asciicast](https://asciinema.org/a/dCzY67dR6Ph07X2XLEdoGe9FC.svg)](https://asciinema.org/a/dCzY67dR6Ph07X2XLEdoGe9FC)
 


### PR DESCRIPTION
Closes #82

## What
Expands the two ARM64 canary legs from #81 to the full cross product: matrix axes `runner: [ubuntu-24.04, ubuntu-24.04-arm]` x the eight distro configs, 16 integration legs total. ARM64 jobs get an ` (ARM64)` name suffix; amd64 job names are unchanged and the aggregate `Gate` check covers everything without a branch-protection change. The README tested-on list simplifies to "each on x86_64 and arm64".

## Why safe
All eight base images are multi-arch manifests, every package source the scripts add ships arm64 (the deb PGDG line already declares `arch=amd64,arm64`, Adoptium and the OpenNMS repos publish aarch64/arm64), and four of the eight combos were already proven green on ARM64 (Ubuntu 24.04 + AlmaLinux 10 in CI, Debian 13 + AlmaLinux 9 locally, evidence on #46). The remaining four install identical upstream packages from the same EL9/EL10 repos. Accepted trade-off: more legs give transient flakes more surface on the required Gate; arm64 runners are free for public repos, so cost is not a factor.

## Verification
`make lint` (actionlint) passes; this PR's checks list is the real test — 16 matrix jobs plus Lint and Gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)